### PR TITLE
require pathname in simplecov-lcov.rb instead of spec_helper.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ group :development do
   gem 'jeweler', '~> 2.0.1'
   gem 'simplecov'
   gem 'coveralls', require: false
-  gem 'activesupport'
+  gem 'activesupport', '~> 4.1.10'
 end

--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'pathname'
 
 fail 'simplecov-lcov requires simplecov' unless defined?(SimpleCov)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'simplecov'
 require 'coveralls'
-require 'pathname'
 require 'fileutils'
 
 module SimpleCov::Configuration


### PR DESCRIPTION
We should require 'pathname' where Pathname is actually used to avoid errors like:
```
Formatter SimpleCov::Formatter::LcovFormatter failed with NameError: uninitialized constant Class::Pathname (simplecov-lcov-0.4.0/lib/simplecov-lcov.rb:41:in `single_report_path')
```