### PR TITLE
Relativize paths in output file to SimpleCov.root as in other formatters

### DIFF
--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -69,7 +69,8 @@ module SimpleCov
       end
 
       def format_file(file)
-        "SF:#{file.filename}\n#{format_lines(file)}\nend_of_record\n"
+        filename = file.filename.gsub("#{SimpleCov.root}/", './')
+        "SF:#{filename}\n#{format_lines(file)}\nend_of_record\n"
       end
 
       def format_lines(file)

--- a/spec/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov
+++ b/spec/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov
@@ -1,4 +1,4 @@
-SF:/path/to/repository/spec/fixtures/app/models/user.rb
+SF:./spec/fixtures/app/models/user.rb
 DA:4,2
 DA:5,2
 DA:6,2

--- a/spec/fixtures/lcov/spec-fixtures-hoge.rb.lcov
+++ b/spec/fixtures/lcov/spec-fixtures-hoge.rb.lcov
@@ -1,4 +1,4 @@
-SF:/path/to/repository/spec/fixtures/hoge.rb
+SF:./spec/fixtures/hoge.rb
 DA:4,1
 DA:5,2
 DA:6,2

--- a/spec/simplecov-lcov_spec.rb
+++ b/spec/simplecov-lcov_spec.rb
@@ -38,7 +38,6 @@ describe SimpleCov::Formatter::LcovFormatter do
         }
         let(:fixture) {
           File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-hoge.rb.lcov")
-            .gsub('/path/to/repository/spec', File.dirname(__FILE__))
         }
         it { expect(File.read(output_path)).to eq(fixture) }
       end
@@ -49,7 +48,6 @@ describe SimpleCov::Formatter::LcovFormatter do
         }
         let(:fixture) {
           File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov")
-            .gsub('/path/to/repository/spec', File.dirname(__FILE__))
         }
         it { expect(File.read(output_path)).to eq(fixture) }
       end
@@ -77,11 +75,9 @@ describe SimpleCov::Formatter::LcovFormatter do
         }
         let(:fixture_of_hoge) {
           File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-hoge.rb.lcov")
-            .gsub('/path/to/repository/spec', File.dirname(__FILE__))
         }
         let(:fixture_of_user) {
           File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov")
-            .gsub('/path/to/repository/spec', File.dirname(__FILE__))
         }
         it { expect(File.read(output_path)).to match(fixture_of_hoge) }
         it { expect(File.read(output_path)).to match(fixture_of_user) }


### PR DESCRIPTION
Paths should be outputed in relative form, not absolute. This make sense if you like to process lcov file in other machine then your own for ex.: on coveralls.io or Sonar instance.