### PR TITLE
Add custom path option for single file reports.

### DIFF
--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -18,11 +18,17 @@ module SimpleCov
           result.files.each { |file| write_lcov!(file) }
         end
 
-        puts "Lcov style coverage report generated for #{result.command_name} to #{SimpleCov::Formatter::LcovFormatter.output_directory}."
+        path = if self.class.report_with_single_file?
+          self.class.single_report_path
+        else
+          self.class.output_directory
+        end
+        puts "Lcov style coverage report generated for #{result.command_name} to #{path}."
       end
 
       class << self
         attr_writer :report_with_single_file
+        attr_writer :single_file_report_path
 
         def report_with_single_file?
           !!@report_with_single_file
@@ -32,6 +38,8 @@ module SimpleCov
         # ==== Return
         # Path for output directory.
         def output_directory
+          return File.dirname(@single_file_report_path) if @single_file_report_path
+
           File.join(SimpleCov.coverage_path, 'lcov')
         end
 
@@ -39,6 +47,8 @@ module SimpleCov
         # ==== Return
         # Path for output path of single file report.
         def single_report_path
+          return @single_file_report_path if @single_file_report_path
+
           basename = Pathname.new(SimpleCov.root).basename.to_s
           File.join(output_directory, "#{basename}.lcov")
         end

--- a/spec/simplecov-lcov_spec.rb
+++ b/spec/simplecov-lcov_spec.rb
@@ -107,7 +107,7 @@ describe SimpleCov::Formatter::LcovFormatter do
       end
 
       after {
-        SimpleCov::Formatter::LcovFormatter.remove_instance_variable :@single_file_report_path
+        SimpleCov::Formatter::LcovFormatter.__send__ :remove_instance_variable, :@single_file_report_path
       }
     end
   end

--- a/spec/simplecov-lcov_spec.rb
+++ b/spec/simplecov-lcov_spec.rb
@@ -87,6 +87,29 @@ describe SimpleCov::Formatter::LcovFormatter do
         it { expect(@output).to include('Lcov style coverage report') }
       end
     end
+
+    context 'generating single file report with custom path' do
+      before {
+        @path = 'a/b/c/lcov.d'
+        SimpleCov::Formatter::LcovFormatter.report_with_single_file = true
+        SimpleCov::Formatter::LcovFormatter.single_file_report_path = @path
+      }
+
+      describe 'single_report_path' do
+        it { expect(SimpleCov::Formatter::LcovFormatter.single_report_path).to eq(@path) }
+      end
+
+      describe 'output_directory' do
+        let(:directory) {
+          File.dirname(@path)
+        }
+        it { expect(SimpleCov::Formatter::LcovFormatter.output_directory).to eq(directory) }
+      end
+
+      after {
+        SimpleCov::Formatter::LcovFormatter.remove_instance_variable :@single_file_report_path
+      }
+    end
   end
 
   describe '.output_directory' do


### PR DESCRIPTION
This adds an option to override the path that single file reports are written to. The reason I need this feature is so I can have my report at "coverage/lcov.info" which is the only path supported by the Atom plugin lcov-info.
