### PR TITLE
Add more options for configuring single file report

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,9 +27,19 @@ Custom SimpleCov formatter to generate a lcov style coverage.
 ```Ruby
   require 'simplecov'
   require 'simplecov-lcov'
-  SimpleCov::Formatter::LcovFormatter.report_with_single_file = true
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
   SimpleCov.start
+```
+
+Other available configuration options for single file report:
+
+```Ruby
+  SimpleCov::Formatter::LcovFormatter.config do |c|
+    c.output_directory = 'your/path' # default: "coverage/lcov"
+    c.lcov_file_name = 'lcov.info' # default: "YOUR_PROJECT_NAME.lcov"
+    c.single_report_path = 'your/path/lcov.info'
+  end
 ```
 
 ## Contributing to simplecov-lcov

--- a/lib/simple_cov_lcov/configuration.rb
+++ b/lib/simple_cov_lcov/configuration.rb
@@ -1,0 +1,24 @@
+module SimpleCovLcov
+  class Configuration
+    attr_writer :report_with_single_file
+    attr_writer :output_directory
+    attr_writer :lcov_file_name
+    attr_writer :single_report_path
+
+    def report_with_single_file?
+      !!@report_with_single_file
+    end
+
+    def output_directory
+      @output_directory || File.join(SimpleCov.coverage_path, 'lcov')
+    end
+
+    def single_report_path
+      @single_report_path || File.join(output_directory, lcov_file_name)
+    end
+
+    def lcov_file_name
+      @lcov_file_name || "#{Pathname.new(SimpleCov.root).basename}.lcov"
+    end
+  end
+end

--- a/lib/simple_cov_lcov/configuration.rb
+++ b/lib/simple_cov_lcov/configuration.rb
@@ -3,7 +3,6 @@ module SimpleCovLcov
     attr_writer :report_with_single_file
     attr_writer :output_directory
     attr_writer :lcov_file_name
-    attr_writer :single_report_path
 
     def report_with_single_file?
       !!@report_with_single_file
@@ -11,6 +10,11 @@ module SimpleCovLcov
 
     def output_directory
       @output_directory || File.join(SimpleCov.coverage_path, 'lcov')
+    end
+
+    def single_report_path=(new_path)
+      self.output_directory = File.dirname(new_path)
+      @single_report_path = new_path
     end
 
     def single_report_path

--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -31,6 +31,12 @@ module SimpleCov
         end
 
         def report_with_single_file=(value)
+          deprecation_message = \
+            "#{caller(1..1).first} " \
+            "`#{LcovFormatter}.report_with_single_file=` is deprecated. " \
+            "Use `#{LcovFormatter}.config.report_with_single_file=` instead"
+
+          warn deprecation_message
           config.report_with_single_file = value
         end
       end

--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -20,7 +20,7 @@ module SimpleCov
           result.files.each { |file| write_lcov!(file) }
         end
 
-        puts "Lcov style coverage report generated for #{result.command_name} to #{lcov_results_path}."
+        puts "Lcov style coverage report generated for #{result.command_name} to #{lcov_results_path}"
       end
 
       class << self

--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'pathname'
+require_relative 'simple_cov_lcov/configuration'
 
 fail 'simplecov-lcov requires simplecov' unless defined?(SimpleCov)
 
@@ -12,53 +13,59 @@ module SimpleCov
       # _result_ :: [SimpleCov::Result] abcoverage result instance.
       def format(result)
         create_output_directory!
-        if self.class.report_with_single_file?
+
+        if report_with_single_file?
           write_lcov_to_single_file!(result.files)
         else
           result.files.each { |file| write_lcov!(file) }
         end
 
-        puts "Lcov style coverage report generated for #{result.command_name} to #{SimpleCov::Formatter::LcovFormatter.output_directory}."
+        puts "Lcov style coverage report generated for #{result.command_name} to #{lcov_results_path}."
       end
 
       class << self
-        attr_writer :report_with_single_file
-
-        def report_with_single_file?
-          !!@report_with_single_file
+        def config
+          @config ||= SimpleCovLcov::Configuration.new
+          yield @config if block_given?
+          @config
         end
 
-        # Output directory for generated files.
-        # ==== Return
-        # Path for output directory.
-        def output_directory
-          File.join(SimpleCov.coverage_path, 'lcov')
-        end
-
-        # Output path for single file report.
-        # ==== Return
-        # Path for output path of single file report.
-        def single_report_path
-          basename = Pathname.new(SimpleCov.root).basename.to_s
-          File.join(output_directory, "#{basename}.lcov")
+        def report_with_single_file=(value)
+          config.report_with_single_file = value
         end
       end
 
       private
 
+      def output_directory
+        self.class.config.output_directory
+      end
+
+      def lcov_results_path
+        report_with_single_file? ? single_report_path : output_directory
+      end
+
+      def report_with_single_file?
+        self.class.config.report_with_single_file?
+      end
+
+      def single_report_path
+        self.class.config.single_report_path
+      end
+
       def create_output_directory!
-        return if Dir.exist?(self.class.output_directory)
-        FileUtils.mkdir_p(self.class.output_directory)
+        return if Dir.exist?(output_directory)
+        FileUtils.mkdir_p(output_directory)
       end
 
       def write_lcov!(file)
-        File.open(File.join(self.class.output_directory, output_filename(file.filename)), 'w') do |f|
+        File.open(File.join(output_directory, output_filename(file.filename)), 'w') do |f|
           f.write format_file(file)
         end
       end
 
       def write_lcov_to_single_file!(files)
-        File.open(self.class.single_report_path, 'w') do |f|
+        File.open(single_report_path, 'w') do |f|
           files.each { |file| f.write format_file(file) }
         end
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -33,6 +33,20 @@ describe SimpleCovLcov::Configuration do
     end
   end
 
+  describe '#report_with_single_file?' do
+    context 'when no customisations are made' do
+      it { is_expected.not_to be_report_with_single_file }
+    end
+
+    context 'when report_with_single_file set to true' do
+      before do
+        configuration.report_with_single_file = true
+      end
+
+      it { is_expected.to be_report_with_single_file }
+    end
+  end
+
   describe '#single_report_path' do
     let(:default_single_report_dir) { File.join(SimpleCov.coverage_path, 'lcov') }
     let(:default_file_name) { 'simplecov-lcov.lcov' }

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,75 @@
+require_relative 'spec_helper'
+
+describe SimpleCovLcov::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe '#output_directory' do
+    context 'when directory is not customized' do
+      it 'returns default directory path' do
+        expect(configuration.output_directory).to eq File.join(SimpleCov.coverage_path, 'lcov')
+      end
+    end
+
+    context 'when directory is customized' do
+      let(:custom_directory_path) { 'some/custom/path' }
+
+      before do
+        configuration.output_directory = custom_directory_path
+      end
+
+      it 'returns customized directory path' do
+        expect(configuration.output_directory).to eq custom_directory_path
+      end
+    end
+  end
+
+  describe '#single_report_path' do
+    let(:default_single_report_dir) { File.join(SimpleCov.coverage_path, 'lcov') }
+    let(:default_file_name) { 'simplecov-lcov.lcov' }
+
+    context 'when no path customisations where made' do
+      it 'returns default path' do
+        default_path = File.join(default_single_report_dir, default_file_name)
+        expect(configuration.single_report_path).to eq default_path
+      end
+    end
+
+    context 'when file name is customised' do
+      let(:custom_file_name) { 'my-custom-file.info' }
+
+      before do
+        configuration.lcov_file_name = custom_file_name
+      end
+
+      it 'returns path with custom file name' do
+        path_with_custom_file_name = File.join(default_single_report_dir, custom_file_name)
+        expect(configuration.single_report_path).to eq path_with_custom_file_name
+      end
+    end
+
+    context 'when output directory is customised' do
+      let(:custom_file_directory) { 'path/to/my/custom/dir' }
+
+      before do
+        configuration.output_directory = custom_file_directory
+      end
+
+      it 'returns path with custom file name' do
+        customized_path = File.join(custom_file_directory, default_file_name)
+        expect(configuration.single_report_path).to eq customized_path
+      end
+    end
+
+    context 'when single_report_path is customised' do
+      let(:custom_path) { 'my/path/with/file.lcov' }
+
+      before do
+        configuration.single_report_path = custom_path
+      end
+
+      it 'returns customised path' do
+        expect(configuration.single_report_path).to eq custom_path
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -21,6 +21,16 @@ describe SimpleCovLcov::Configuration do
         expect(configuration.output_directory).to eq custom_directory_path
       end
     end
+
+    context 'when single_report_path is customized' do
+      before do
+        configuration.single_report_path = 'some/custom/path/lcov.info'
+      end
+
+      it 'sets correct path' do
+        expect(configuration.output_directory).to eq 'some/custom/path'
+      end
+    end
   end
 
   describe '#single_report_path' do

--- a/spec/simplecov-lcov_spec.rb
+++ b/spec/simplecov-lcov_spec.rb
@@ -78,4 +78,11 @@ module SimpleCov::Formatter
       end
     end
   end
+
+  describe '.report_with_single_file=' do
+    it 'sets configuration options correctly' do
+      expect(LcovFormatter.config).to receive(:report_with_single_file=)
+      LcovFormatter.report_with_single_file = true
+    end
+  end
 end

--- a/spec/simplecov-lcov_spec.rb
+++ b/spec/simplecov-lcov_spec.rb
@@ -1,84 +1,81 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'active_support/core_ext/kernel/reporting'
 
-describe SimpleCov::Formatter::LcovFormatter do
-  describe '#format' do
-    let(:expand_path) {
-      lambda do |filename|
-        File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', filename))
-      end
-    }
-
-    let(:simplecov_result_hash) {
-      {
-       expand_path.call('hoge.rb') => [nil, nil, nil, 1, 2, 2, 1, nil, 0, 0, 0, 1],
-       expand_path.call('app/models/user.rb') => [nil, nil, nil, 2, 2, 2, 2, nil, 0, 0, 0, nil, 1, 0, 0, 1]
-      }
-    }
-
-    let(:simplecov_result) {
-      SimpleCov::Result.new(simplecov_result_hash)
-    }
-
-    context 'generating report per file' do
-      before {
-        SimpleCov::Formatter::LcovFormatter.new.format(simplecov_result)
+module SimpleCov::Formatter
+  describe LcovFormatter do
+    describe '#format' do
+      let(:expand_path) {
+        lambda do |filename|
+          File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', filename))
+        end
       }
 
-      describe File do
-        it { expect(File).to exist(File.join(SimpleCov::Formatter::LcovFormatter.output_directory, 'spec-fixtures-hoge.rb.lcov')) }
-        it { expect(File).to exist(File.join(SimpleCov::Formatter::LcovFormatter.output_directory, 'spec-fixtures-app-models-user.rb.lcov')) }
+      let(:simplecov_result_hash) {
+        {
+        expand_path.call('hoge.rb') => [nil, nil, nil, 1, 2, 2, 1, nil, 0, 0, 0, 1],
+        expand_path.call('app/models/user.rb') => [nil, nil, nil, 2, 2, 2, 2, nil, 0, 0, 0, nil, 1, 0, 0, 1]
+        }
+      }
+
+      let(:simplecov_result) {
+        SimpleCov::Result.new(simplecov_result_hash)
+      }
+
+      context 'generating report per file' do
+        before {
+          LcovFormatter.new.format(simplecov_result)
+        }
+
+        describe File do
+          it { expect(File).to exist(File.join(LcovFormatter.config.output_directory, 'spec-fixtures-hoge.rb.lcov')) }
+          it { expect(File).to exist(File.join(LcovFormatter.config.output_directory, 'spec-fixtures-app-models-user.rb.lcov')) }
+        end
+
+        describe 'spec-fixtures-hoge.rb.lcov' do
+          let(:output_path) {
+            File.join(LcovFormatter.config.output_directory, 'spec-fixtures-hoge.rb.lcov')
+          }
+          let(:fixture) {
+            File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-hoge.rb.lcov")
+          }
+          it { expect(File.read(output_path)).to eq(fixture) }
+        end
+
+        describe 'spec-fixtures-app-models-user.rb.lcov' do
+          let(:output_path) {
+            File.join(LcovFormatter.config.output_directory, 'spec-fixtures-app-models-user.rb.lcov')
+          }
+          let(:fixture) {
+            File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov")
+          }
+          it { expect(File.read(output_path)).to eq(fixture) }
+        end
       end
 
-      describe 'spec-fixtures-hoge.rb.lcov' do
-        let(:output_path) {
-          File.join(SimpleCov::Formatter::LcovFormatter.output_directory, 'spec-fixtures-hoge.rb.lcov')
+      context 'generating single file report' do
+        before {
+          LcovFormatter.config.report_with_single_file = true
+          LcovFormatter.new.format(simplecov_result)
         }
-        let(:fixture) {
-          File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-hoge.rb.lcov")
-        }
-        it { expect(File.read(output_path)).to eq(fixture) }
-      end
 
-      describe 'spec-fixtures-app-models-user.rb.lcov' do
-        let(:output_path) {
-          File.join(SimpleCov::Formatter::LcovFormatter.output_directory, 'spec-fixtures-app-models-user.rb.lcov')
-        }
-        let(:fixture) {
-          File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov")
-        }
-        it { expect(File.read(output_path)).to eq(fixture) }
+        describe File do
+          it { expect(File).to exist(LcovFormatter.config.single_report_path) }
+        end
+
+        describe 'single_report_path' do
+          let(:output_path) {
+            LcovFormatter.config.single_report_path
+          }
+          let(:fixture_of_hoge) {
+            File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-hoge.rb.lcov")
+          }
+          let(:fixture_of_user) {
+            File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov")
+          }
+          it { expect(File.read(output_path)).to match(fixture_of_hoge) }
+          it { expect(File.read(output_path)).to match(fixture_of_user) }
+        end
       end
     end
-
-    context 'generating single file report' do
-      before {
-        SimpleCov::Formatter::LcovFormatter.report_with_single_file = true
-        SimpleCov::Formatter::LcovFormatter.new.format(simplecov_result)
-      }
-
-      describe File do
-        it { expect(File).to exist(SimpleCov::Formatter::LcovFormatter.single_report_path) }
-      end
-
-      describe 'single_report_path' do
-        let(:output_path) {
-          SimpleCov::Formatter::LcovFormatter.single_report_path
-        }
-        let(:fixture_of_hoge) {
-          File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-hoge.rb.lcov")
-        }
-        let(:fixture_of_user) {
-          File.read("#{File.dirname(__FILE__)}/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov")
-        }
-        it { expect(File.read(output_path)).to match(fixture_of_hoge) }
-        it { expect(File.read(output_path)).to match(fixture_of_user) }
-      end
-    end
-  end
-
-  describe '.output_directory' do
-    subject { SimpleCov::Formatter::LcovFormatter.output_directory }
-    it { expect(subject).to eq(File.join(SimpleCov.coverage_path, 'lcov')) }
   end
 end

--- a/spec/simplecov-lcov_spec.rb
+++ b/spec/simplecov-lcov_spec.rb
@@ -80,9 +80,19 @@ module SimpleCov::Formatter
   end
 
   describe '.report_with_single_file=' do
+    before do
+      allow(LcovFormatter).to receive(:warn)
+      allow(LcovFormatter.config).to receive(:report_with_single_file=)
+    end
+
     it 'sets configuration options correctly' do
-      expect(LcovFormatter.config).to receive(:report_with_single_file=)
       LcovFormatter.report_with_single_file = true
+      expect(LcovFormatter.config).to have_received(:report_with_single_file=).with(true)
+    end
+
+    it 'shows deprecation warning' do
+      LcovFormatter.report_with_single_file = true
+      expect(LcovFormatter).to have_received(:warn).with(/LcovFormatter\.report_with_single_file=` is deprecated/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,10 +12,10 @@ SimpleCov.configure do
   clean_filters
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 
 ENV['COVERAGE'] && SimpleCov.start do
   add_filter '/.rvm/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,10 +33,10 @@ require 'simplecov-lcov'
 
 RSpec.configure do |config|
   config.before(:each) do
-    if Dir.exist?(SimpleCov::Formatter::LcovFormatter.output_directory)
+    if Dir.exist?(SimpleCov::Formatter::LcovFormatter.config.output_directory)
       FileUtils
         .remove_dir(
-                    SimpleCov::Formatter::LcovFormatter.output_directory,
+                    SimpleCov::Formatter::LcovFormatter.config.output_directory,
                     true
                    )
     end


### PR DESCRIPTION
This improvement allows to customize single file path. It should fix #17. It's also related (kind of duplicated) with #19 #18 and #16, since it allows to do all the things mentioned in other PR's