### PR TITLE
Fix incompatibility with simplecov < 0.18

### DIFF
--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -87,7 +87,7 @@ module SimpleCov
         pieces << "SF:#{filename}"
         pieces << format_lines(file)
 
-        if SimpleCov.branch_coverage?
+        if SimpleCov.respond_to?(:branch_coverage?) && SimpleCov.branch_coverage?
           branch_data = format_branches(file)
           pieces << branch_data if branch_data.length > 0
           pieces << "BRF:#{file.total_branches.length}"


### PR DESCRIPTION
`SimpleCov.branch_coverage?` was added in simplecov 0.18. When an older version of simplecov is installed, the lcov formatter dies in the middle of generating the output.

> Formatter SimpleCov::Formatter::LcovFormatter failed with NoMethodError: undefined method `branch_coverage?' for SimpleCov:Module (/usr/local/var/rbenv/versions/2.3.8/lib/ruby/gems/2.3.0/gems/simplecov-lcov-0.8.0/lib/simplecov-lcov.rb:90:in `format_file')

Unfortunately this project's gemspec doesn't specify the version of simplecov that it requires. So the solution is to check for the existence of this method before calling it.

This doesn't fix release 0.8.0 of simplecov-lcov. So a project could still install an incompatible combination of simplecov and simplecov-lcov. But with this change in a newer release, they should end up with a compatible combination of the two packages.