### PR TITLE
Fix instance variable not initialized warning

### DIFF
--- a/lib/simple_cov_lcov/configuration.rb
+++ b/lib/simple_cov_lcov/configuration.rb
@@ -18,7 +18,7 @@ module SimpleCovLcov
     end
 
     def single_report_path
-      @single_report_path || File.join(output_directory, lcov_file_name)
+      @single_report_path ||= File.join(output_directory, lcov_file_name)
     end
 
     def lcov_file_name


### PR DESCRIPTION
When `report_with_single_file` is true, reading from `single_report_path`
without calling `single_report_path=` causes ruby to issue a warning:

    warning: instance variable @single_report_path not initialized

Fixes the warning by initialising the `@single_report_path` instance
variable with the default.