### PR TITLE
write out LF and LH to LCOV file

### DIFF
--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -86,6 +86,8 @@ module SimpleCov
         pieces = []
         pieces << "SF:#{filename}"
         pieces << format_lines(file)
+        pieces << "LF:#{file.lines.filter { |el| el.coverage }.count}"
+        pieces << "LH:#{file.lines.filter { |el| el.coverage && el.coverage > 0}.count}"
 
         if SimpleCov.branch_coverage?
           branch_data = format_branches(file)


### PR DESCRIPTION
compute LF and LH from SimpleCov coverage(.resultset.json), and write out to LCOV file.

definitions: (same as BRF & BRH)
> LF: number of lines with a non-zero execution count
> LF: number of instrumented lines

refers to: https://github.com/linux-test-project/lcov/blob/92e21217d3e487952e8fab49f98d3560fbde4be8/man/geninfo.1#L576-L577