### PR TITLE
Avoid blank lines in lcov output

### DIFF
--- a/lib/simplecov-lcov.rb
+++ b/lib/simplecov-lcov.rb
@@ -85,7 +85,8 @@ module SimpleCov
         filename = file.filename.gsub("#{SimpleCov.root}/", './')
         pieces = []
         pieces << "SF:#{filename}"
-        pieces << format_lines(file)
+        lines = format_lines(file)
+        pieces << lines if lines.length > 0
 
         if SimpleCov.branch_coverage?
           branch_data = format_branches(file)


### PR DESCRIPTION
I hit a scenario where simplecov-lcov was creating lcov files with blank lines.  This happened on a file that only had comments,  no Ruby content.

The file (ignore the tags, I don't think they relate to the problem):

```ruby
# @!override Class#subclasses
#   @return [Array<Class>]
```

The output:

```lcov
SF:./lib/solargraph/rails/annotations/class.rb

BRF:0
BRH:0
end_of_record
```

This blank line caused issues with a downstream tool - https://github.com/aki77/reviewdog-action-code-coverage/ - which uses https://github.com/gifnksm/lcov/ to process lcov files, choking on the blank lines.