### PR TITLE
fix: update branch references from main to master

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 name: Release Please
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   workflow_dispatch:
 
 jobs:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,7 +8,7 @@ This repository uses:
 
 ## Normal flow
 
-1. Merge changes to `main` using Conventional Commits.
+1. Merge changes to `master` using Conventional Commits.
 2. `release-please` creates a **Release PR** (bumps `lib/simplecov/lcov/version.rb` and updates `CHANGELOG.md`).
 3. Merge the Release PR → a GitHub Release and tag `vX.Y.Z` are created.
 4. The **Publish** workflow runs on `release: published` and pushes the gem to RubyGems.
@@ -24,5 +24,5 @@ This repository uses:
 
 - **Single source of truth (SSOT)** for version is `SimpleCov::Lcov::VERSION` in `lib/simplecov/lcov/version.rb`.
 - Do **not** manually edit `CHANGELOG.md`; it's auto-generated.
-- Protect `main` branch and require CI checks to pass before merge.
+- Protect `master` branch and require CI checks to pass before merge.
 - If you ever need a manual release, you can trigger `release-please` via `workflow_dispatch`.


### PR DESCRIPTION
## Summary
Updated branch references from `main` to `master` in CI/CD configuration and documentation to maintain consistency.

## Changes
- `.github/workflows/release-please.yml`: Changed release workflow trigger branch to `master`
- `docs/RELEASING.md`: Updated branch references in documentation to `master`

## Why
The repository uses `master` as the default branch, so we need to ensure configuration files and documentation are aligned.

## Impact
- Release-please workflow will work correctly when pushing to `master` branch
- Documentation now matches the actual branch structure