### PR TITLE
Improve gemspec and gem release security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 # Add dependencies required to use your gem here.
 # Example:
 #   gem 'activesupport', '>= 2.3.5'

--- a/README.markdown
+++ b/README.markdown
@@ -2,11 +2,10 @@
 
 Custom SimpleCov formatter to generate a lcov style coverage.
 
-[![Build Status](https://travis-ci.org/fortissimo1997/simplecov-lcov.svg?branch=master)](https://travis-ci.org/fortissimo1997/simplecov-lcov)
+[![CI](https://github.com/fortissimo1997/simplecov-lcov/actions/workflows/ci.yml/badge.svg)](https://github.com/fortissimo1997/simplecov-lcov/actions/workflows/ci.yml)
 [![Coverage Status](https://img.shields.io/coveralls/fortissimo1997/simplecov-lcov.svg)](https://coveralls.io/r/fortissimo1997/simplecov-lcov)
-[![Gem Version](https://badge.fury.io/rb/simplecov-lcov.svg)](http://badge.fury.io/rb/simplecov-lcov)
-[![Inline docs](http://inch-ci.org/github/fortissimo1997/simplecov-lcov.svg?branch=master)](http://inch-ci.org/github/fortissimo1997/simplecov-lcov)
-[![Code Climate](https://codeclimate.com/github/fortissimo1997/simplecov-lcov.png)](https://codeclimate.com/github/fortissimo1997/simplecov-lcov)
+[![Gem Version](https://badge.fury.io/rb/simplecov-lcov.svg)](https://badge.fury.io/rb/simplecov-lcov)
+[![Inline docs](https://inch-ci.org/github/fortissimo1997/simplecov-lcov.svg?branch=master)](https://inch-ci.org/github/fortissimo1997/simplecov-lcov)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/fortissimo1997/simplecov-lcov/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/fortissimo1997/simplecov-lcov/?branch=master)
 
 ## Usage

--- a/simplecov-lcov.gemspec
+++ b/simplecov-lcov.gemspec
@@ -3,55 +3,35 @@
 require_relative "lib/simplecov/lcov/version"
 
 Gem::Specification.new do |s|
-  s.name = "simplecov-lcov".freeze
+  s.name = "simplecov-lcov"
   s.version = SimpleCov::Lcov::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib".freeze]
-  s.authors = ["fortissimo1997".freeze]
-  s.date = Time.now.strftime("%Y-%m-%d")
-  s.description = "Custom SimpleCov formatter to generate a lcov style coverage.".freeze
-  s.email = "fortissimo1997@gmail.com".freeze
+  s.require_paths = ["lib"]
+  s.authors = ["fortissimo1997"]
+  s.description = "Custom SimpleCov formatter to generate a lcov style coverage."
+  s.email = "fortissimo1997@gmail.com"
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.markdown"
   ]
   s.files = [
-    ".coveralls.yml",
-    ".document",
-    ".rspec",
-    ".tachikoma.yml",
-    "Gemfile",
     "LICENSE.txt",
     "README.markdown",
-    "Rakefile",
     "lib/simplecov/lcov/version.rb",
     "lib/simple_cov_lcov/configuration.rb",
-    "lib/simplecov-lcov.rb",
-    "simplecov-lcov.gemspec",
-    "spec/configuration_spec.rb",
-    "spec/fixtures/app/models/user.rb",
-    "spec/fixtures/hoge.rb",
-    "spec/fixtures/lcov/spec-fixtures-blank.rb.branch.lcov",
-    "spec/fixtures/lcov/spec-fixtures-blank.rb.lcov",
-    "spec/fixtures/lcov/spec-fixtures-app-models-user.rb.branch.lcov",
-    "spec/fixtures/lcov/spec-fixtures-app-models-user.rb.lcov",
-    "spec/fixtures/lcov/spec-fixtures-hoge.rb.branch.lcov",
-    "spec/fixtures/lcov/spec-fixtures-hoge.rb.lcov",
-    "spec/simplecov-lcov_spec.rb",
-    "spec/spec_helper.rb"
+    "lib/simplecov-lcov.rb"
   ]
-  s.homepage = "http://github.com/fortissimo1997/simplecov-lcov".freeze
-  s.licenses = ["MIT".freeze]
-  s.rubygems_version = "3.7.1".freeze
-  s.summary = "Custom SimpleCov formatter to generate a lcov style coverage.".freeze
+  s.homepage = "https://github.com/fortissimo1997/simplecov-lcov"
+  s.licenses = ["MIT"]
+  s.required_ruby_version = ">= 2.4.0"
+  s.summary = "Custom SimpleCov formatter to generate a lcov style coverage."
+  s.metadata["rubygems_mfa_required"] = "true"
 
-  s.add_development_dependency(%q<rspec>.freeze, [">= 0"])
-  s.add_development_dependency(%q<rdoc>.freeze, [">= 0"])
-  s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
-  s.add_development_dependency(%q<rake>.freeze, [">= 0"])
-  s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.18"])
-  s.add_development_dependency(%q<coveralls>.freeze, [">= 0"])
-  s.add_development_dependency(%q<activesupport>.freeze, [">= 0"])
+  s.add_development_dependency(%q<rspec>, [">= 0"])
+  s.add_development_dependency(%q<rdoc>, [">= 0"])
+  s.add_development_dependency(%q<bundler>, [">= 0"])
+  s.add_development_dependency(%q<rake>, [">= 0"])
+  s.add_development_dependency(%q<simplecov>, ["~> 0.18"])
+  s.add_development_dependency(%q<coveralls>, [">= 0"])
+  s.add_development_dependency(%q<activesupport>, [">= 0"])
 end
-


### PR DESCRIPTION
Hello,

thanks for this library, I'm advising to use it at https://github.com/tagliala/coveralls-ruby-reborn?tab=readme-ov-file#github-actions to allow coveralls run on github actions without the coveralls library

I've noticed that there was this new release and I'm sending this PR

---

**Enforce MFA for privileged operations**

Require multi-factor authentication for all privileged operations by any
gem owner, increasing release security.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/

**Remove redundant `.freeze` calls**

Eliminate unnecessary `.freeze` on string literals—already immutable
due to the magic comment.

This was auto-corrected by RuboCop:

```
rubocop --only Style/RedundantFreeze -a simplecov-lcov.gemspec
```

**Exclude development files from gem package**

Omit spec and configuration files from the production gem, reducing
package size from 10.5KB to 7KB.

**Specify minimum required Ruby version**

Explicitly set Ruby version to match SimpleCov (>= 2.4.0). Though
redundant, this improves Rubygems metadata and suppresses a build
warning.

**Remove redundant `*_rubygems_version` fields from gemspec**

Setting required_rubygems_version to ">= 0" is the default in RubyGems
(i.e., "no minimum RubyGems required"), so it doesn't change behavior.
The `respond_to?` guard is only relevant for very old RubyGems versions
that predate this attribute. The minimum required Ruby version, `2.4.0`,
ships with a RubyGems 2.x series that already defines
`required_rubygems_version=`, making the guard unnecessary.

RubyGems automatically records the RubyGems version used to build the
gem. Specifying `rubygems_version` in the gemspec has no effect at
runtime. Keeping this field in source can cause drift and harms
reproducible builds. The recommended practice is to omit it.

**Drop explicit date from gemspec**

RubyGems sets the build date when packaging; the `date` field is
optional and unnecessary in modern gemspecs.

**Additional changes**

- Replace Travis CI badge with GitHub Actions' one
- Use https where possible
- Remove CodeClimate badge (CodeClimate is no longer working and
  rebranded as Qlty)
